### PR TITLE
fix) IAM Policy from AmazonConnectFullAccess to AmazonConnect_FullAccess

### DIFF
--- a/DemoGoPrime_CFN.json
+++ b/DemoGoPrime_CFN.json
@@ -909,7 +909,7 @@
                     ]
                 },
                 "ManagedPolicyArns": [
-                    "arn:aws:iam::aws:policy/AmazonConnectFullAccess",
+                    "arn:aws:iam::aws:policy/AmazonConnect_FullAccess",
                     "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess",
                     "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
                 ]


### PR DESCRIPTION
CloudFormation Stack fails for IAM policy name is changed from AmazonConnectFullAccess to AmazonConnect_FullAccess. This commit fixes this issue